### PR TITLE
Header gets cut off

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewer.scss
+++ b/client/src/components/HistoryViewer/HistoryViewer.scss
@@ -58,7 +58,6 @@
 
 // Todo: remove this when the CMS is React driven and we don't need this hack
 .history-viewer-preview {
-  margin-top: -54px;
   position: relative;
   display: flex;
 


### PR DESCRIPTION
Should resolve: https://github.com/silverstripe/silverstripe-versioned-snapshot-admin/issues/15 by removing the negative margin, worst case is there is white space at the top which is preferable over losing content