### PR TITLE
Use the time of the snapshot as users care about that

### DIFF
--- a/client/src/graphql/snapshotsQuery.js
+++ b/client/src/graphql/snapshotsQuery.js
@@ -43,7 +43,6 @@ query ReadSnapshotsPage ($page_id: ID!, $limit: Int!, $offset: Int!) {
             }
             LiveVersion
             LatestDraftVersion
-            LastEdited
           }
         }
       }


### PR DESCRIPTION
Currently we get the last edited from the origin node and overwrite the snapshot with that value. This means that is you wrote an object at `11:00:02` and it had a relation (e.g. an image) that was written at `11:00:03` then when you look at snapshots the image snapshot will point to `11:00:02` so when you click to preview the image you'll not see it.

This fixes that.