### PR TITLE
Avoid race conditions by prefixing everything with Snapshot 📸

### DIFF
--- a/client/src/boot/registerComponents.js
+++ b/client/src/boot/registerComponents.js
@@ -11,25 +11,34 @@ import HistoryViewerSnapshot from 'components/HistoryViewer/HistoryViewerSnapsho
 import HistoryViewerCompareWarning from 'components/HistoryViewer/HistoryViewerCompareWarning';
 import snapshotQuery from 'graphql/snapshotsQuery';
 
+/**
+ * The reason we have not gone down the route of using the same name for components
+ * is that we were running into race conditions with the injector. For example we
+ * had the HistoryViewer component having two graphql HoCs applied to it. The last one
+ * applied would "win" and update it's state
+ *
+ * We've opted to go down the route of renaming references rather than names in the hopes that
+ * in the future when the injector is able to support removing registered HoC's
+ */
 export default () => {
   Injector.component.register('SnapshotViewer', HistoryViewer);
-  Injector.component.register('HistoryViewer', HistoryViewer);
+  Injector.component.register('SnapshotHistoryViewer', HistoryViewer);
   Injector.component.registerMany({
-    HistoryViewerHeading,
-    HistoryViewerToolbar,
-    HistoryViewerVersion,
-    HistoryViewerVersionDetail,
-    HistoryViewerVersionList,
-    HistoryViewerVersionState,
-    HistoryViewerSnapshotState,
-    HistoryViewerSnapshot,
-    HistoryViewerCompareWarning,
+    SnapshotHistoryViewerHeading: HistoryViewerHeading,
+    SnapshotHistoryViewerToolbar: HistoryViewerToolbar,
+    SnapshotHistoryViewerVersion: HistoryViewerVersion,
+    SnapshotHistoryViewerVersionDetail: HistoryViewerVersionDetail,
+    SnapshotHistoryViewerVersionList: HistoryViewerVersionList,
+    SnapshotHistoryViewerVersionState: HistoryViewerVersionState,
+    SnapshotHistoryViewerSnapshotState: HistoryViewerSnapshotState,
+    SnapshotHistoryViewerSnapshot: HistoryViewerSnapshot,
+    SnapshotHistoryViewerCompareWarning: HistoryViewerCompareWarning,
   }, { force: true });
   Injector.transform(
     'snapshot-history',
     (updater) => {
       // Add CMS page history GraphQL query to the HistoryViewer
-      updater.component('SnapshotViewer.pages-controller-cms-content', snapshotQuery, 'PageHistoryViewer');
+      updater.component('SnapshotViewer.pages-controller-cms-content', snapshotQuery);
     }
   );
 };

--- a/client/src/boot/registerReducers.js
+++ b/client/src/boot/registerReducers.js
@@ -5,7 +5,7 @@ import historyViewerReducer from 'state/historyviewer/HistoryViewerReducer';
 const registerReducers = () => {
   Injector.reducer.register('versionedAdmin', combineReducers({
     historyViewer: historyViewerReducer,
-  }));
+  }), { force: true });
 };
 
 export default registerReducers;

--- a/client/src/components/HistoryViewer/HistoryViewer.js
+++ b/client/src/components/HistoryViewer/HistoryViewer.js
@@ -64,7 +64,7 @@ class HistoryViewer extends Component {
   componentWillUnmount() {
     const { onSelect } = this.props;
     if (typeof onSelect === 'function') {
-      onSelect(0);
+      onSelect(false);
     }
   }
 
@@ -485,7 +485,7 @@ export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   historyViewerConfig,
   inject(
-    ['HistoryViewerVersionList', 'HistoryViewerVersionDetail', 'HistoryViewerCompareWarning'],
+    ['SnapshotHistoryViewerVersionList', 'SnapshotHistoryViewerVersionDetail', 'SnapshotHistoryViewerCompareWarning'],
     (ListComponent, VersionDetailComponent, CompareWarningComponent) => ({
       ListComponent,
       VersionDetailComponent,

--- a/client/src/components/HistoryViewer/HistoryViewerSnapshot.js
+++ b/client/src/components/HistoryViewer/HistoryViewerSnapshot.js
@@ -116,7 +116,7 @@ function mapDispatchToProps(dispatch) {
 export default compose(
   connect(null, mapDispatchToProps),
   inject(
-    ['FormAction', 'HistoryViewerSnapshotState'],
+    ['FormAction', 'SnapshotHistoryViewerSnapshotState'],
     (FormAction, HistoryViewerSnapshotState) => ({
         FormActionComponent: FormAction,
         StateComponent: HistoryViewerSnapshotState,

--- a/client/src/components/HistoryViewer/HistoryViewerVersion.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersion.js
@@ -279,7 +279,7 @@ function mapDispatchToProps(dispatch) {
 export default compose(
   connect(null, mapDispatchToProps),
   inject(
-    ['HistoryViewerVersionState', 'FormAction'],
+    ['SnapshotHistoryViewerVersionState', 'FormAction'],
     (StateComponent, FormActionComponent) => ({
       StateComponent,
       FormActionComponent,

--- a/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionDetail.js
@@ -252,7 +252,7 @@ HistoryViewerVersionDetail.defaultProps = {
 export { HistoryViewerVersionDetail as Component };
 
 export default inject(
-  ['HistoryViewerVersionList', 'HistoryViewerToolbar', 'Preview', 'HistoryViewerCompareWarning'],
+  ['SnapshotHistoryViewerVersionList', 'SnapshotHistoryViewerToolbar', 'Preview', 'SnapshotHistoryViewerCompareWarning'],
   (ListComponent, ToolbarComponent, PreviewComponent, CompareWarningComponent) => ({
     ListComponent,
     ToolbarComponent,

--- a/client/src/components/HistoryViewer/HistoryViewerVersionList.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionList.js
@@ -168,7 +168,7 @@ export { HistoryViewerVersionList as Component };
 export default compose(
   connect(mapStateToProps),
   inject(
-    ['FormAlert', 'HistoryViewerHeading', 'HistoryViewerVersion', 'HistoryViewerSnapshot'],
+    ['FormAlert', 'SnapshotHistoryViewerHeading', 'SnapshotHistoryViewerVersion', 'SnapshotHistoryViewerSnapshot'],
     (FormAlert, HistoryViewerHeading, HistoryViewerVersion, HistoryViewerSnapshot) => ({
       FormAlertComponent: FormAlert,
       HeadingComponent: HistoryViewerHeading,

--- a/client/src/containers/HistoryViewer/HistoryViewerConfig.js
+++ b/client/src/containers/HistoryViewer/HistoryViewerConfig.js
@@ -54,7 +54,7 @@ const historyViewerConfig = (HistoryViewer) => {
   }
 
   return inject(
-    ['HistoryViewer']
+    ['SnapshotHistoryViewer']
   )(HistoryViewerConfigProvider);
 };
 

--- a/client/src/legacy/HistoryViewer/HistoryViewerEntwine.js
+++ b/client/src/legacy/HistoryViewer/HistoryViewerEntwine.js
@@ -8,7 +8,7 @@ import { loadComponent } from 'lib/Injector';
  * outside of a React context e.g. in the CMS
  */
 jQuery.entwine('ss', ($) => {
-  $('.js-injector-boot .history-viewer__container').entwine({
+  $('.js-injector-boot .snapshot-history-viewer__container').entwine({
     onmatch() {
       const cmsContent = this.closest('.cms-content').attr('id');
       const context = (cmsContent)

--- a/src/SnapshotViewerField.php
+++ b/src/SnapshotViewerField.php
@@ -20,4 +20,13 @@ class SnapshotViewerField extends HistoryViewerField
         Requirements::javascript('silverstripe/versioned-snapshot-admin:client/dist/js/bundle.js');
     }
 
+    public function Type(): string
+    {
+        return 'snapshot-history-viewer__container';
+    }
+
+    public function getName(): string
+    {
+        return 'snapshot-history-viewer__container';
+    }
 }


### PR DESCRIPTION
This avoids race conditions by prefixing the names of things with Snapshot.
It also fixes an unmounting bug where we were setting a version to an invalid prop type