### PR TITLE
Install correct dependencies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,9 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer install --prefer-dist
-  - composer require silverstripe/recipe-core:4.4.x-dev silverstripe/versioned:1.4.x-dev --prefer-dist --no-update
-  - composer update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --prefer-dist; fi
+  - composer require silverstripe/recipe-core:4.5.x-dev silverstripe/versioned:1.5.x-dev --no-update
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi


### PR DESCRIPTION
This PR does:

 - Install correct versions of recipe-core and versioned (4.5)
 - Installs composer dependencies more efficiently (speeding up builds)