### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,15 @@
-language: php
+version: ~> 1.0
+
+import:
+  - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=dev-master
-
-matrix:
-  fast_finish: true
+    - REQUIRE_RECIPE="4.x-dev"
+  
+jobs:
   include:
-#    - php: 5.6
-#      env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
-#    - php: 7.0
-#      env: DB=MYSQL PHPUNIT_TEST=1
-#    - php: 7.1
-#      env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
-    - php: 7.2
-      env: DB=MYSQL NPM_TEST=1
-#    - php: 7.3
-#      env: DB=MYSQL PHPUNIT_TEST=1
-
-before_script:
-# Init PHP
-  - printf "\n" | pecl install imagick
-  - phpenv rehash
-  - phpenv config-rm xdebug.ini
-  - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
-# Install composer
-  - composer validate
-  - composer require silverstripe/recipe-core:4.5.x-dev silverstripe/versioned:1.5.x-dev --no-update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
-  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
-
-script:
-  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
-  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-  - if [[ $PHPCS_TEST ]]; then composer validate; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-
-after_success:
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi
+    - php: 7.4
+      env:
+        - DB=MYSQL
+        - NPM_TEST=1


### PR DESCRIPTION
It configured (but skipped) PHPUnit tests which the module doesn't have,
and *didnt'* run NPM tests which the module does have.

Example:
https://travis-ci.com/github/silverstripe/silverstripe-versioned-snapshot-admin/builds/225145963

Note that the tests are currently failing, which I believe shouldn't block this merge - it just surfaces existing issues.