### PR TITLE
FIX Remove implicit dep on silverstripe/cms

### DIFF
--- a/_graphql/schema.yml
+++ b/_graphql/schema.yml
@@ -3,6 +3,7 @@ config:
     DataObject:
       plugins:
         snapshotHistory: true
+  execute: [ SilverStripe\SnapshotAdmin\SnapshotHistoryExtension ]
 models:
   SilverStripe\Security\Member:
     fields:


### PR DESCRIPTION
Was relying on GraphQL "admin" schema in silverstripe/cms
to add at least one query. Without queries, the admin schema doesn't build.

Note that this could also be fixed by forcing custom implementations without the cms
to execute SnapshotHistoryExtension->updateSchema() directly,
but this solution is a bit more "plug and play". It does come at the cost of looping
through all classes on the admin schema build, although ClassInfo makes that reasonably low cost.