### PR TITLE
Update admin requirement to allow for installation on recipe-cms 4.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "silverstripe/framework": "^4",
         "silverstripe/versioned-snapshots": "dev-master",
         "silverstripe/versioned-admin": "^1",
-        "silverstripe/admin": "< 1.7",
+        "silverstripe/admin": "^1",
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {


### PR DESCRIPTION
Since recipe-cms 4.8 still requires graphql 3, the current requirement meant this module could not be installed at any version