### PR TITLE
Activity ago is not displaying on history view versions

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewerVersion.js
+++ b/client/src/components/HistoryViewer/HistoryViewerVersion.js
@@ -210,7 +210,7 @@ class HistoryViewerVersion extends Component {
           tabIndex={0}
         >
           <span className="history-viewer__message" role="cell">
-            <span>{version.ActivityAgo}</span>
+            <span>{version.activityAgo}</span>
             {' '}
             <small className="text-muted">{getDateFromVersion(version)}</small>
           </span>


### PR DESCRIPTION
Only displaying on snapshots and not versions because HistoryViewerVersion.js wasn't updated during https://github.com/silverstripe/silverstripe-versioned-snapshot-admin/pull/63 