### PR TITLE
NEW: Basic module setup (linting, tests).

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,11 @@
+checks:
+  php: true
+
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
+filter:
+  paths: ["src/*", "tests/*"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 version: ~> 1.0
 
-import:
-  - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
-
 env:
   global:
+    - COMPOSER_ROOT_VERSION="4.x-dev"
     - REQUIRE_RECIPE="4.x-dev"
-  
-jobs:
-  include:
-    - php: 7.4
-      env:
-        - DB=MYSQL
-        - NPM_TEST=1
+
+import:
+  - silverstripe/silverstripe-travis-shared:config/provision/standard-jobs-fixed.yml

--- a/composer.json
+++ b/composer.json
@@ -22,19 +22,18 @@
     "require": {
         "silverstripe/framework": "^4",
         "silverstripe/graphql": "^4 | >= 3.5.1",
-        "silverstripe/versioned-snapshots": "dev-master",
+        "silverstripe/versioned-snapshots": "1.x-dev",
         "silverstripe/versioned-admin": "^1",
-        "silverstripe/admin": ">= 1.7",
+        "silverstripe/admin": "^1.7",
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
         "silverstripe/versioned": "^1",
-        "squizlabs/php_codesniffer": "^3"
+        "silverstripe/recipe-testing": "^1 || ^2"
     },
     "autoload": {
         "psr-4": {
-            "SilverStripe\\SnapshotAdmin\\": ["src/", "_legacy/"],
+            "SilverStripe\\SnapshotAdmin\\": "src/",
             "SilverStripe\\SnapshotAdmin\\Tests\\": "tests/"
         }
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="SilverStripe">
-	<description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <file>src</file>
+    <file>tests</file>
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
-	<!-- base rules are PSR-2 -->
-	<rule ref="PSR2" >
-		<!-- Current exclusions -->
-		<exclude name="PSR1.Methods.CamelCapsMethodName" />
-		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-		<exclude name="PSR2.Classes.PropertyDeclaration" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
-		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
-		<exclude name="Squiz.Scope.MethodScope" />
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-		<exclude name="Generic.Files.LineLength.TooLong" />
-		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
-	</rule>
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2" >
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName" />
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+        <exclude name="PSR2.Classes.PropertyDeclaration" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+        <exclude name="Squiz.Scope.MethodScope" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+    </rule>
 </ruleset>
-

--- a/src/CMSMainExtension.php
+++ b/src/CMSMainExtension.php
@@ -7,7 +7,7 @@ use SilverStripe\View\Requirements;
 
 class CMSMainExtension extends Extension
 {
-    public function init()
+    public function init(): void
     {
         Requirements::javascript('silverstripe/versioned-snapshot-admin:client/dist/js/bundle.js');
         Requirements::css('silverstripe/versioned-snapshot-admin:client/dist/styles/bundle.css');

--- a/src/SnapshotAdmin.php
+++ b/src/SnapshotAdmin.php
@@ -1,50 +1,77 @@
 <?php
 
-
 namespace SilverStripe\SnapshotAdmin;
 
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\SnapshotVersioned;
 
 /**
  * Temporary shim to provide rollback POC
+ *
  * @package SilverStripe\Snapshots
  */
 class SnapshotAdmin extends LeftAndMain
 {
+    /**
+     * @var string
+     */
     private static $url_segment = 'snapshot';
 
+    /**
+     * @var string
+     */
     private static $url_rule = '/$Action';
 
+    /**
+     * @var int
+     */
     private static $url_priority = 10;
 
+    /**
+     * @var string
+     */
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
+    /**
+     * @var bool
+     */
     private static $ignore_menuitem = true;
 
+    /**
+     * @var array
+     */
     private static $url_handlers = [
-        'rollback/$RecordClass!/$RecordID!/$Snapshot!' => 'handleRollback'
+        'rollback/$RecordClass!/$RecordID!/$Snapshot!' => 'handleRollback',
     ];
 
+    /**
+     * @var array
+     */
     private static $allowed_actions = [
         'handleRollback',
     ];
 
+    /**
+     * @param HTTPRequest $request
+     * @return mixed
+     * @throws HTTPResponse_Exception
+     */
     public function handleRollback(HTTPRequest $request)
     {
         $class = $request->param('RecordClass');
         $id = $request->param('RecordID');
         $snapshot = urldecode($request->param('Snapshot'));
         $class = str_replace('__', '\\', $class);
-        /* @var SnapshotPublishable|SnapshotVersioned $record */
+
+        /** @var SnapshotPublishable|SnapshotVersioned $record */
         $record = DataObject::get_by_id($class, $id);
 
         if (!$record) {
             $this->httpError(404);
-            return;
         }
 
         $record->doRollbackToSnapshot($snapshot);

--- a/src/SnapshotHistoryExtension.php
+++ b/src/SnapshotHistoryExtension.php
@@ -1,16 +1,17 @@
 <?php
 
-
 namespace SilverStripe\SnapshotAdmin;
 
+use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Control\Director;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * @method BaseElement|$this getOwner()
+ */
 class SnapshotHistoryExtension extends DataExtension
 {
     /**
@@ -18,28 +19,28 @@ class SnapshotHistoryExtension extends DataExtension
      */
     public function isSnapshotable(): bool
     {
-        return (
-            $this->owner->hasExtension(Versioned::class) &&
-            $this->owner->hasExtension(SnapshotPublishable::class) &&
-            !$this->owner instanceof SiteTree
-        );
+        $owner = $this->getOwner();
+
+        return
+            $owner->hasExtension(Versioned::class) &&
+            $owner->hasExtension(SnapshotPublishable::class) &&
+            !$owner instanceof SiteTree;
     }
 
     /**
      * @param FieldList $fields
      * @return void|null
      */
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
         if ($fields->findTab('Root.History')) {
-            return null;
-        }
-        if (!$this->owner->isSnapshotable()) {
-            return null;
+            return;
         }
 
-        $fields->addFieldToTab('Root.History', SnapshotViewerField::create(
-            'SnapshotHistory'
-        ));
+        if (!$this->getOwner()->isSnapshotable()) {
+            return;
+        }
+
+        $fields->addFieldToTab('Root.History', SnapshotViewerField::create('SnapshotHistory'));
     }
 }

--- a/src/SnapshotPublishableExtension.php
+++ b/src/SnapshotPublishableExtension.php
@@ -2,39 +2,30 @@
 
 namespace SilverStripe\SnapshotAdmin;
 
+use Exception;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataList;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
-use SilverStripe\ORM\DB;
-use SilverStripe\Snapshots\Snapshot;
-use SilverStripe\Snapshots\SnapshotHasher;
-use SilverStripe\Snapshots\SnapshotItem;
+use SilverStripe\Snapshots\SnapshotPublishable;
 
+/**
+ * Enhance
+ */
 class SnapshotPublishableExtension extends DataExtension
 {
-    use SnapshotHasher;
-
     /**
      * We want to get the version that the snapshots should point to
+     * Extension point in @see SnapshotPublishable::getRelevantSnapshots()
+     *
+     * @throws Exception
      */
-    public function updateRelevantSnapshots(DataList &$result)
+    public function updateRelevantSnapshots(DataList &$result): void
     {
-        $snapshotTable = DataObject::getSchema()->tableName(Snapshot::class);
-        $itemTable = DataObject::getSchema()->tableName(SnapshotItem::class);
-        $hash = static::hashObjectForSnapshot($this->owner);
-        $result = $result->alterDataQuery(function (DataQuery $query) use ($hash, $snapshotTable, $itemTable) {
-            $subquery = <<<SQL
-                (
-                  SELECT "Version" FROM "$itemTable"
-                  WHERE "ObjectHash" = ? AND "$itemTable"."SnapshotID" = "$snapshotTable"."ID"
-                )
-SQL;
-            $query->selectField(
-                DB::inline_parameters($subquery, [$hash]),
-                'baseVersion'
-            );
-            return $query;
-        });
+        $itemVersionColumn = null;
+        $result = $result
+            ->applyRelation('Items.Version', $itemVersionColumn)
+            ->alterDataQuery(static function (DataQuery $query) use ($itemVersionColumn) {
+                $query->selectField($itemVersionColumn, 'baseVersion');
+            });
     }
 }

--- a/src/SnapshotViewerField.php
+++ b/src/SnapshotViewerField.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\SnapshotAdmin;
 
 use SilverStripe\CMS\Model\SiteTree;
@@ -12,9 +11,16 @@ use SilverStripe\View\Requirements;
 
 class SnapshotViewerField extends HistoryViewerField
 {
-
+    /**
+     * @var string
+     */
     protected $schemaComponent = 'SnapshotViewerContainer';
 
+    /**
+     * @param mixed $name
+     * @param mixed $title
+     * @param mixed $value
+     */
     public function __construct($name, $title = null, $value = null)
     {
         parent::__construct($name, $title, $value);
@@ -32,14 +38,16 @@ class SnapshotViewerField extends HistoryViewerField
         return 'snapshot-history-viewer__container';
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
         $record = $this->getSourceRecord();
 
         // GraphQL doesn't have any API for "hide ancestor", which we should support at some point
         // to avoid things like readSiteTree. "Page" is exposed by default
-        $baseClass = $record->baseClass() === SiteTree::class ? 'Page' : $record->baseClass();
+        $baseClass = $record->baseClass() === SiteTree::class
+            ? 'Page'
+            : $record->baseClass();
 
         // GraphQL 4
         if (class_exists(SchemaBuilder::class)) {
@@ -47,6 +55,7 @@ class SnapshotViewerField extends HistoryViewerField
             $data['data'] = array_merge($data['data'], [
                 'typeName' => $config->getTypeNameForClass($baseClass),
             ]);
+
             return $data;
         }
 
@@ -59,6 +68,7 @@ class SnapshotViewerField extends HistoryViewerField
         $data['data'] = array_merge($data['data'], [
             'typeName' => StaticSchema::inst()->typeNameForDataObject($baseClass),
         ]);
+
         return $data;
     }
 }

--- a/tests/SnapshotPublishableExtensionTest.php
+++ b/tests/SnapshotPublishableExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SilverStripe\SnapshotAdmin\Tests;
+
+use Page;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Snapshots\Snapshot;
+use SilverStripe\Snapshots\SnapshotEvent;
+use SilverStripe\Snapshots\SnapshotItem;
+use SilverStripe\Snapshots\SnapshotPublishable;
+
+class SnapshotTest extends SapphireTest
+{
+    /**
+     * @var bool
+     */
+    protected $usesDatabase = true;
+
+    /**
+     * @var array
+     */
+    protected static $extra_dataobjects = [
+        SnapshotItem::class,
+        Snapshot::class,
+        SnapshotEvent::class,
+        Page::class,
+    ];
+
+    /**
+     * @throws ValidationException
+     */
+    public function testUpdateRelevantSnapshots(): void
+    {
+        /** @var Page|SnapshotPublishable $a1 */
+        $a1 = Page::create();
+        $a1->Title = 'A1 Block Page';
+        $this->snapshot($a1);
+
+        $snapshots = $a1->getRelevantSnapshots();
+        $versions = $snapshots->column('baseVersion');
+        $versions = array_unique($versions);
+        $this->assertSame([(int) $a1->Version], $versions);
+    }
+
+    /**
+     * @param DataObject $obj
+     * @param array $extraObjects
+     * @return Snapshot
+     * @throws ValidationException
+     */
+    private function snapshot(DataObject $obj, array $extraObjects = []): Snapshot
+    {
+        $obj->write();
+        $obj = DataObject::get_by_id($obj->ClassName, $obj->ID, false);
+        $snapshot = Snapshot::singleton()->createSnapshot($obj, $extraObjects);
+        $snapshot->write();
+
+        return $snapshot;
+    }
+}


### PR DESCRIPTION
# NEW: Basic module setup (linting, tests)

* Travis automated tests run setup
* Composer configuration update to cover the needed dependencies to run tests
* Linting fixes
* No functional or behavioural changes
* PHP 8 compatibility fixes
* Raw queries changed to ORM calls

## Out of scope of this PR

* Deep integration

These will be covered separate change-sets

## Related issues

https://github.com/silverstripe/silverstripe-versioned-snapshots/issues/51