### PR TITLE
BUG: Fluent module compatibility

### DIFF
--- a/src/SnapshotHistoryPlugin.php
+++ b/src/SnapshotHistoryPlugin.php
@@ -159,7 +159,7 @@ class SnapshotHistoryPlugin implements ModelTypePlugin, SchemaUpdater
 
         // Get all snapshots
         $list = $object->getRelevantSnapshots();
-        $list = $list->sort('"LastEdited"', 'DESC');
+        $list = $list->sort('LastEdited', 'DESC');
         // To check if the items are the full versions we compare their hashes against the objects hash
         // this is used in the frontend to show the user if the snapshot is from the object itself
         // or one of its children

--- a/src/SnapshotPublishableExtension.php
+++ b/src/SnapshotPublishableExtension.php
@@ -23,7 +23,7 @@ class SnapshotPublishableExtension extends DataExtension
     {
         $itemVersionColumn = null;
         $result = $result
-            ->applyRelation('Items.Version', $itemVersionColumn)
+            ->applyRelation('Items.ObjectVersion', $itemVersionColumn)
             ->alterDataQuery(static function (DataQuery $query) use ($itemVersionColumn) {
                 $query->selectField($itemVersionColumn, 'baseVersion');
             });


### PR DESCRIPTION
# BUG: Fluent module compatibility

Compatibility changes for Fluent module.

## Rename Version field to ObjectVersion to prevent conflicts with reserved field

`Version` is a special model property that should not be redefined on any model. `SnapshotItem` currently has a `Version` property which may cause some random issues (especially when forceChange() is called). This change renames `Version` to `ObjectVersion` to prevent random issues and it's also more accurate as the version refers to the related object not the item itself.

## Depends on

https://github.com/silverstripe/silverstripe-versioned-snapshots/pull/56