### PR TITLE
MNT Migrate JavaScript tests to @testing-library/react

### DIFF
--- a/client/src/components/HistoryViewer/tests/HistoryViewer-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewer-test.js
@@ -1,13 +1,27 @@
 /* global jest, describe, it, expect */
 
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { Component as HistoryViewer } from '../HistoryViewer';
 
 describe('HistoryViewer', () => {
   const ListComponent = () => <table />;
   const VersionDetailComponent = () => <div />;
   const CompareWarningComponent = () => <div />;
+
+  // Render the component and expose both its instance (for the methods under test) and the
+  // rendered DOM container. The three child components are stubbed for every render.
+  const renderViewer = (props = {}) => {
+    const ref = React.createRef();
+    const { container } = render(<HistoryViewer
+      ref={ref}
+      ListComponent={ListComponent}
+      VersionDetailComponent={VersionDetailComponent}
+      CompareWarningComponent={CompareWarningComponent}
+      {...props}
+    />);
+    return { component: ref.current, container };
+  };
 
   // Mock select functions to replace the ones provided by mapDispatchToProps
   let mockOnSelect;
@@ -63,16 +77,13 @@ describe('HistoryViewer', () => {
   describe('getVersions()', () => {
     // Verifies getVersions() flattens the snapshotHistory edges into version objects
     it('returns the node element from each version edge', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        versions={versions}
-        recordId={1}
-        recordClass="MockType"
-        limit={100}
-        compare={false}
-      />);
+      const { component } = renderViewer({
+        versions,
+        recordId: 1,
+        recordClass: 'MockType',
+        limit: 100,
+        compare: false,
+      });
 
       expect(component.getVersions().map((version) => version.version)).toEqual([14, 13]);
     });
@@ -81,38 +92,32 @@ describe('HistoryViewer', () => {
   describe('getLatestVersion()', () => {
     // Verifies getLatestVersion() picks the list item flagged latestDraftVersion when none is selected
     it('returns the version marked as latestDraftVersion', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        versions={versions}
-        recordId={1}
-        recordClass="MockType"
-        limit={100}
-        page={1}
-        compare={false}
-      />);
+      const { component } = renderViewer({
+        versions,
+        recordId: 1,
+        recordClass: 'MockType',
+        limit: 100,
+        page: 1,
+        compare: false,
+      });
 
       expect(component.getLatestVersion().version).toEqual(13);
     });
 
     // Verifies getLatestVersion() prefers a selected currentVersion (flagged latest draft) over the list
     it('gives priority to the currentVersion', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        versions={versions}
-        recordId={1}
-        recordClass="MockType"
-        limit={100}
-        page={1}
-        compare={false}
-        currentVersion={{
+      const { component } = renderViewer({
+        versions,
+        recordId: 1,
+        recordClass: 'MockType',
+        limit: 100,
+        page: 1,
+        compare: false,
+        currentVersion: {
           version: 123,
           latestDraftVersion: true
-        }}
-      />);
+        },
+      });
 
       expect(component.getLatestVersion().version).toEqual(123);
     });
@@ -121,40 +126,33 @@ describe('HistoryViewer', () => {
   describe('render()', () => {
     // Verifies render() shows the loading spinner while the `loading` prop is set
     it('shows a loading state while loading results', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        versions={versions}
-        recordId={1}
-        recordClass="MockType"
-        limit={100}
-        loading
-      />);
+      const { container } = renderViewer({
+        versions,
+        recordId: 1,
+        recordClass: 'MockType',
+        limit: 100,
+        loading: true,
+      });
 
-      const result = ReactTestUtils
-        .scryRenderedDOMComponentsWithTag(component, 'cms-content-loading-spinner');
+      const result = container.querySelectorAll('.cms-content-loading-spinner');
 
-      expect(result).toBeTruthy();
+      expect(result).toHaveLength(1);
     });
   });
 
   describe('handleSetPage()', () => {
     // Verifies handleSetPage() forwards the requested page number to onSetPage
     it('dispatches onSetPage with the requested page number', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-        compare={false}
-      />);
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+        compare: false,
+      });
       component.handleSetPage(1);
       expect(mockOnSetPage).toBeCalledWith(1);
     });
@@ -163,19 +161,16 @@ describe('HistoryViewer', () => {
   describe('onSelect()', () => {
     // Verifies componentWillUnmount() calls onSelect(0) to clear the selected version
     it('called when components unmounts', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-        compare={false}
-      />);
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+        compare: false,
+      });
 
       component.componentWillUnmount();
       expect(mockOnSelect).toBeCalled();
@@ -185,68 +180,59 @@ describe('HistoryViewer', () => {
   describe('isListView()', () => {
     // Verifies isListView() is true when no version is selected and compare is off
     it('returns true when no current version or compare mode is set', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-        currentVersion={false}
-        compare={false}
-      />);
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+        currentVersion: false,
+        compare: false,
+      });
 
       expect(component.isListView()).toBe(true);
     });
 
     // Verifies isListView() is false when a version is selected and compare is off (detail view)
     it('returns false current version is set and compare mode is not', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-        currentVersion={{
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+        currentVersion: {
           ID: 1,
-        }}
-        compare={false}
-      />);
+        },
+        compare: false,
+      });
 
       expect(component.isListView()).toBe(false);
     });
 
     // Verifies isListView() is true when only the compare "from" side is set
     it('returns true when current version is set with only compare FROM', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-        currentVersion={{
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+        currentVersion: {
           ID: 1,
-        }}
-        compare={{
+        },
+        compare: {
           versionFrom: {
             ID: 1,
           },
-        }}
-      />);
+        },
+      });
 
       expect(component.isListView()).toBe(true);
     });
@@ -255,30 +241,27 @@ describe('HistoryViewer', () => {
     it('returns false when in compare mode', () => {
       // `loading` renders the early loading branch so we don't mount the detail view (which
       // pulls in the real ResizeAware); isListView() is a pure read of compare/currentVersion.
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-        loading
-        currentVersion={{
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+        loading: true,
+        currentVersion: {
           ID: 1
-        }}
-        compare={{
+        },
+        compare: {
           versionFrom: {
             ID: 1,
           },
           versionTo: {
             ID: 2,
           },
-        }}
-      />);
+        },
+      });
 
       expect(component.isListView()).toBe(false);
     });
@@ -287,43 +270,37 @@ describe('HistoryViewer', () => {
   describe('compareModeAvailable()', () => {
     // Verifies compareModeAvailable() is true when more than one version exists
     it('returns true when more than one version is present', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={versions}
-      />);
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions,
+      });
 
       expect(component.compareModeAvailable()).toBe(true);
     });
 
     // Verifies compareModeAvailable() is false when fewer than two versions are parseable
     it('returns false with only one version', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewer
-        ListComponent={ListComponent}
-        VersionDetailComponent={VersionDetailComponent}
-        CompareWarningComponent={CompareWarningComponent}
-        recordId={1}
-        recordClass="MockType"
-        onSelect={mockOnSelect}
-        onSetPage={mockOnSetPage}
-        limit={1}
-        page={2}
-        versions={{
+      const { component } = renderViewer({
+        recordId: 1,
+        recordClass: 'MockType',
+        onSelect: mockOnSelect,
+        onSetPage: mockOnSetPage,
+        limit: 1,
+        page: 2,
+        versions: {
           Versions: {
             pageInfo: { totalCount: 1 },
             edges: [
               { node: { Version: 14 } },
             ],
           }
-        }}
-      />);
+        },
+      });
 
       expect(component.compareModeAvailable()).toBe(false);
     });

--- a/client/src/components/HistoryViewer/tests/HistoryViewerHeading-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerHeading-test.js
@@ -1,7 +1,7 @@
 /* global jest, describe, it, expect */
 
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { Component as HistoryViewerHeading } from '../HistoryViewerHeading';
 
 describe('HistoryViewerHeading', () => {
@@ -12,25 +12,29 @@ describe('HistoryViewerHeading', () => {
   describe('handleCompareModeChange()', () => {
     // Verifies handleCompareModeChange() calls onCompareModeUnselect when compare mode is on
     it('notifies the store to leave compare mode when it is currently selected', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerHeading
+      const ref = React.createRef();
+      render(<HistoryViewerHeading
+        ref={ref}
         compareModeSelected
         onCompareModeSelect={mockOnCompareModeSelect}
         onCompareModeUnselect={mockOnCompareModeUnselect}
       />);
 
-      component.handleCompareModeChange();
+      ref.current.handleCompareModeChange();
       expect(mockOnCompareModeUnselect).toHaveBeenCalled();
     });
 
     // Verifies handleCompareModeChange() calls onCompareModeSelect when compare mode is off
     it('notifies the store to enter compare mode when it is not currently selected', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerHeading
+      const ref = React.createRef();
+      render(<HistoryViewerHeading
+        ref={ref}
         compareModeSelected={false}
         onCompareModeSelect={mockOnCompareModeSelect}
         onCompareModeUnselect={mockOnCompareModeUnselect}
       />);
 
-      component.handleCompareModeChange();
+      ref.current.handleCompareModeChange();
       expect(mockOnCompareModeSelect).toHaveBeenCalled();
     });
   });

--- a/client/src/components/HistoryViewer/tests/HistoryViewerToolbar-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerToolbar-test.js
@@ -1,7 +1,7 @@
 /* global jest, describe, it, expect */
 
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render, act } from '@testing-library/react';
 import { Component as HistoryViewerToolbar } from '../HistoryViewerToolbar';
 
 describe('HistoryViewerToolbar', () => {
@@ -20,8 +20,10 @@ describe('HistoryViewerToolbar', () => {
 
   describe('handleRevert()', () => {
     // Verifies handleRevert() calls the rollback mutation with the record/version, then onAfterRevert
-    it('runs the rollback mutation then onAfterRevert on success', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerToolbar
+    it('runs the rollback mutation then onAfterRevert on success', async () => {
+      const ref = React.createRef();
+      render(<HistoryViewerToolbar
+        ref={ref}
         onAfterRevert={revertHandler}
         RollbackMutation={RollbackMutation}
         FormActionComponent={FormActionComponent}
@@ -32,13 +34,15 @@ describe('HistoryViewerToolbar', () => {
         typeName="MockType"
       />);
 
-      return component.handleRevert(mockRollback, 123, 'MockClass', 234)
-        .then(() => {
-          expect(mockRollback).toHaveBeenCalledWith({
-            variables: { id: 123, dataClass: 'MockClass', toVersion: 234 },
-          });
-          expect(revertHandler).toHaveBeenCalledWith(234);
-        });
+      // handleRevert sets state and resolves asynchronously, so run it inside act()
+      await act(async () => {
+        await ref.current.handleRevert(mockRollback, 123, 'MockClass', 234);
+      });
+
+      expect(mockRollback).toHaveBeenCalledWith({
+        variables: { id: 123, dataClass: 'MockClass', toVersion: 234 },
+      });
+      expect(revertHandler).toHaveBeenCalledWith(234);
     });
   });
 });

--- a/client/src/components/HistoryViewer/tests/HistoryViewerVersion-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerVersion-test.js
@@ -1,7 +1,7 @@
 /* global jest, describe, it, expect */
 
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render, fireEvent } from '@testing-library/react';
 import { Component as HistoryViewerVersion } from '../HistoryViewerVersion';
 
 describe('HistoryViewerVersion', () => {
@@ -12,6 +12,19 @@ describe('HistoryViewerVersion', () => {
   let mockOnCompareMode;
   let mockOnSelect;
   let version = {};
+
+  // Render the component and expose both its instance (for the methods under test) and the
+  // rendered DOM container (for class/tag queries)
+  const renderVersion = (props = {}) => {
+    const ref = React.createRef();
+    const { container } = render(<HistoryViewerVersion
+      ref={ref}
+      StateComponent={StateComponent}
+      FormActionComponent={FormActionComponent}
+      {...props}
+    />);
+    return { component: ref.current, container };
+  };
 
   beforeEach(() => {
     mockOnCompareMode = jest.fn();
@@ -34,12 +47,7 @@ describe('HistoryViewerVersion', () => {
   describe('handleCompare()', () => {
     // Verifies handleCompare() dispatches onCompareMode with the current version
     it('calls onCompareMode to dispatch an action as the result of handleCompare call', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        onCompareMode={mockOnCompareMode}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-      />);
+      const { component } = renderVersion({ version, onCompareMode: mockOnCompareMode });
 
       component.handleCompare();
       expect(mockOnCompareMode).toBeCalledWith(version);
@@ -49,25 +57,14 @@ describe('HistoryViewerVersion', () => {
   describe('getAuthor()', () => {
     // Verifies getAuthor() returns the snapshot author's full name
     it('returns the author name when unpublished', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-      />);
+      const { component } = renderVersion({ version });
 
       expect(component.getAuthor()).toEqual('John Smith');
     });
 
     // Verifies getAuthor() still returns the author (not publisher) when the version is published
     it('returns the author name even when published (snapshots track their own author)', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={{
-          ...version,
-          published: true
-        }}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-      />);
+      const { component } = renderVersion({ version: { ...version, published: true } });
 
       expect(component.getAuthor()).toEqual('John Smith');
     });
@@ -76,31 +73,22 @@ describe('HistoryViewerVersion', () => {
   describe('handleClick()', () => {
     // Verifies clicking the row does not select the version while it is active (clear button shown)
     it('does nothing on row click when the clear button is shown', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive
-      />);
+      const { container } = renderVersion({ version, onSelect: mockOnSelect, isActive: true });
 
-      const link = ReactTestUtils
-        .scryRenderedDOMComponentsWithClass(component, 'history-viewer__version-link')[0];
-      ReactTestUtils.Simulate.click(link);
+      const link = container.querySelectorAll('.history-viewer__version-link')[0];
+      fireEvent.click(link);
 
       expect(mockOnSelect).not.toHaveBeenCalled();
     });
 
     // Verifies handleClick() selects the version (compare off) via onSelect
     it('renders version details when version clicked', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive={false}
-        compare={false}
-      />);
+      const { component } = renderVersion({
+        version,
+        onSelect: mockOnSelect,
+        isActive: false,
+        compare: false,
+      });
 
       component.handleClick();
       expect(mockOnSelect).toHaveBeenCalledWith(version, false);
@@ -113,14 +101,12 @@ describe('HistoryViewerVersion', () => {
         versionTo: { version: 0 },
       };
 
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive={false}
-        compare={compare}
-      />);
+      const { component } = renderVersion({
+        version,
+        onSelect: mockOnSelect,
+        isActive: false,
+        compare,
+      });
 
       component.handleClick();
       expect(mockOnSelect).toHaveBeenCalledWith(version, compare);
@@ -128,16 +114,14 @@ describe('HistoryViewerVersion', () => {
 
     // Verifies clicking in compare mode selects the version without toggling compare mode
     it('chooses version when version clicked in compare mode', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        compare={{
+      const { component } = renderVersion({
+        version,
+        onSelect: mockOnSelect,
+        compare: {
           versionFrom: { version: 0 },
           versionTo: { version: 0 },
-        }}
-      />);
+        },
+      });
 
       component.handleClick();
       expect(mockOnSelect).toHaveBeenCalled();
@@ -148,31 +132,17 @@ describe('HistoryViewerVersion', () => {
   describe('render()', () => {
     // Verifies an active row renders the close button
     it('renders the close button in the version details', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive
-      />);
+      const { container } = renderVersion({ version, onSelect: mockOnSelect, isActive: true });
 
-      const buttons = ReactTestUtils
-        .scryRenderedDOMComponentsWithClass(component, 'history-viewer__close-button');
+      const buttons = container.querySelectorAll('.history-viewer__close-button');
       expect(buttons).toHaveLength(1);
     });
 
     // Verifies an active row renders the compare button
     it('renders the compare button in the version details', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive
-      />);
+      const { container } = renderVersion({ version, onSelect: mockOnSelect, isActive: true });
 
-      const buttons = ReactTestUtils
-        .scryRenderedDOMComponentsWithClass(component, 'history-viewer__compare-button');
+      const buttons = container.querySelectorAll('.history-viewer__compare-button');
       expect(buttons).toHaveLength(1);
     });
   });
@@ -180,14 +150,12 @@ describe('HistoryViewerVersion', () => {
   describe('handleClose()', () => {
     // Verifies handleClose() returns to the list view via onSelect
     it('return back to list view when closing version via action dispatch', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive
-        compare={false}
-      />);
+      const { component } = renderVersion({
+        version,
+        onSelect: mockOnSelect,
+        isActive: true,
+        compare: false,
+      });
 
       component.handleClose();
       expect(mockOnSelect).toHaveBeenCalled();
@@ -195,17 +163,15 @@ describe('HistoryViewerVersion', () => {
 
     // Verifies handleClose() in compare mode deselects without toggling compare mode
     it('deselect version when closing version in compare mode', () => {
-      const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersion
-        version={version}
-        StateComponent={StateComponent}
-        FormActionComponent={FormActionComponent}
-        onSelect={mockOnSelect}
-        isActive
-        compare={{
+      const { component } = renderVersion({
+        version,
+        onSelect: mockOnSelect,
+        isActive: true,
+        compare: {
           versionFrom: { version: 0 },
           versionTo: { version: 0 },
-        }}
-      />);
+        },
+      });
 
       component.handleClose();
       expect(mockOnSelect).toHaveBeenCalled();

--- a/client/src/components/HistoryViewer/tests/HistoryViewerVersionList-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerVersionList-test.js
@@ -1,7 +1,7 @@
 /* global jest, describe, it, expect */
 
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { Component as HistoryViewerVersionList } from '../HistoryViewerVersionList';
 
 describe('HistoryViewerVersionList', () => {
@@ -9,19 +9,17 @@ describe('HistoryViewerVersionList', () => {
   const HeadingComponent = () => <li />;
   const VersionComponent = () => <div />;
 
-  const component = ReactTestUtils.renderIntoDocument(<HistoryViewerVersionList
-    FormAlertComponent={FormAlertComponent}
-    HeadingComponent={HeadingComponent}
-    VersionComponent={VersionComponent}
-    versions={[]}
-  />);
-
   describe('render()', () => {
+    // Verifies the list renders as a <ul> carrying the history-viewer table class
     it('returns an unordered list', () => {
-      const list = ReactTestUtils.scryRenderedDOMComponentsWithTag(
-        component,
-        'ul'
-      );
+      const { container } = render(<HistoryViewerVersionList
+        FormAlertComponent={FormAlertComponent}
+        HeadingComponent={HeadingComponent}
+        VersionComponent={VersionComponent}
+        versions={[]}
+      />);
+
+      const list = container.querySelectorAll('ul');
 
       expect(list[0].className).toContain('history-viewer__table');
     });

--- a/client/src/components/HistoryViewer/tests/HistoryViewerVersionState-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerVersionState-test.js
@@ -1,18 +1,24 @@
 /* global jest, describe, it, expect */
 
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { Component as HistoryViewerVersionState } from '../HistoryViewerVersionState';
 
 describe('HistoryViewerVersionState', () => {
   let component = null;
   HistoryViewerVersionState.defaultProps.BadgeComponent = () => <div />;
 
+  // Render the component and return its instance so the methods under test can be called directly
+  const renderState = (props = {}) => {
+    const ref = React.createRef();
+    render(<HistoryViewerVersionState ref={ref} {...props} />);
+    return ref.current;
+  };
+
   describe('getClassNames()', () => {
     // Verifies getClassNames() appends extraClass to the default state class
     it('adds extra classes to the default class', () => {
-      component = ReactTestUtils
-        .renderIntoDocument(<HistoryViewerVersionState extraClass="foobar" />);
+      component = renderState({ extraClass: 'foobar' });
 
       expect(component.getClassNames()).toContain('foobar');
       expect(component.getClassNames()).toContain('history-viewer__version-state');
@@ -26,16 +32,14 @@ describe('HistoryViewerVersionState', () => {
         activityType: 'PUBLISHED'
       };
 
-      component = ReactTestUtils
-        .renderIntoDocument(<HistoryViewerVersionState version={mockVersion} />);
+      component = renderState({ version: mockVersion });
 
       expect(component.getPublishedState()).toBe('Published');
     });
 
     // Verifies getPublishedState() falls back to "Saved" when no activity type is set
     it('defaults to "Saved" if not defined', () => {
-      component = ReactTestUtils
-        .renderIntoDocument(<HistoryViewerVersionState version={{}} />);
+      component = renderState({ version: {} });
 
       expect(component.getPublishedState()).toBe('Saved');
     });
@@ -47,8 +51,7 @@ describe('HistoryViewerVersionState', () => {
       const mockVersion = {
         isLiveSnapshot: true
       };
-      component = ReactTestUtils
-        .renderIntoDocument(<HistoryViewerVersionState version={mockVersion} />);
+      component = renderState({ version: mockVersion });
 
       const badge = component.getBadges();
       expect(badge.props.message).toEqual('Live');
@@ -57,8 +60,7 @@ describe('HistoryViewerVersionState', () => {
 
     // Verifies getBadges() returns an empty string when the version is not live
     it('returns an empty string when version is not live', () => {
-      component = ReactTestUtils
-        .renderIntoDocument(<HistoryViewerVersionState />);
+      component = renderState();
 
       expect(component.getBadges()).toBe('');
     });

--- a/client/src/components/HistoryViewer/tests/HistoryViewerVersionState-test.js
+++ b/client/src/components/HistoryViewer/tests/HistoryViewerVersionState-test.js
@@ -5,7 +5,6 @@ import { render } from '@testing-library/react';
 import { Component as HistoryViewerVersionState } from '../HistoryViewerVersionState';
 
 describe('HistoryViewerVersionState', () => {
-  let component = null;
   HistoryViewerVersionState.defaultProps.BadgeComponent = () => <div />;
 
   // Render the component and return its instance so the methods under test can be called directly
@@ -18,7 +17,7 @@ describe('HistoryViewerVersionState', () => {
   describe('getClassNames()', () => {
     // Verifies getClassNames() appends extraClass to the default state class
     it('adds extra classes to the default class', () => {
-      component = renderState({ extraClass: 'foobar' });
+      const component = renderState({ extraClass: 'foobar' });
 
       expect(component.getClassNames()).toContain('foobar');
       expect(component.getClassNames()).toContain('history-viewer__version-state');
@@ -32,14 +31,14 @@ describe('HistoryViewerVersionState', () => {
         activityType: 'PUBLISHED'
       };
 
-      component = renderState({ version: mockVersion });
+      const component = renderState({ version: mockVersion });
 
       expect(component.getPublishedState()).toBe('Published');
     });
 
     // Verifies getPublishedState() falls back to "Saved" when no activity type is set
     it('defaults to "Saved" if not defined', () => {
-      component = renderState({ version: {} });
+      const component = renderState({ version: {} });
 
       expect(component.getPublishedState()).toBe('Saved');
     });
@@ -51,7 +50,7 @@ describe('HistoryViewerVersionState', () => {
       const mockVersion = {
         isLiveSnapshot: true
       };
-      component = renderState({ version: mockVersion });
+      const component = renderState({ version: mockVersion });
 
       const badge = component.getBadges();
       expect(badge.props.message).toEqual('Live');
@@ -60,7 +59,7 @@ describe('HistoryViewerVersionState', () => {
 
     // Verifies getBadges() returns an empty string when the version is not live
     it('returns an empty string when version is not live', () => {
-      component = renderState();
+      const component = renderState();
 
       expect(component.getBadges()).toBe('');
     });


### PR DESCRIPTION
## Description

Self contained PR to resolve the React 18 `ReactDOM.render is no longer supported` / `ReactDOMTestUtils is deprecated` warnings, as suggested in https://github.com/silverstripe/silverstripe-versioned-snapshot-admin/pull/115#issuecomment-4775030666

Migrates the HistoryViewer tests off the deprecated `react-dom/test-utils` onto `@testing-library/react`. Instances are grabbed via a ref so the assertions stay the same. Tests only, no source changes.

## Manual testing steps

- `yarn install`
- `yarn test`
- all suites pass, no more React 18 deprecation warnings in the output

## Issues

- N/A, follow up to #115

## Pull request checklist

- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR
- [x] The commit messages follow our commit message guidelines
- [x] The PR follows our contribution guidelines
- [x] Code changes follow our coding conventions
- [x] This change is covered with tests (the change is to the tests themselves)
- [x] Any relevant User Help/Developer documentation is updated (`MNT` change, excluded from the changelog)
- [ ] CI is green
