### PR TITLE
MNT Fix Sass declaration-after-nested-rule deprecation warnings

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewer.scss
+++ b/client/src/components/HistoryViewer/HistoryViewer.scss
@@ -86,12 +86,8 @@
     $loading-indicator-speed: 0.9s;
     $loading-indicator-animation: spinner-loader $loading-indicator-speed infinite linear;
 
-    &, &:after {
-      border-radius: 50%;
-      width: $loading-indicator-size;
-      height: $loading-indicator-size;
-    }
-
+    // Declarations must come before the nested rule below; Sass 3.0 will otherwise
+    // change the cascade order for declarations that follow nested rules.
     margin-bottom: 1em;
     font-size: $font-size-sm;
     position: relative;
@@ -103,6 +99,12 @@
     transform: translateZ(0);
     -webkit-animation: $loading-indicator-animation;
     animation: $loading-indicator-animation;
+
+    &, &:after {
+      border-radius: 50%;
+      width: $loading-indicator-size;
+      height: $loading-indicator-size;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Clears the Sass "declaration after nested rules" deprecation warnings that show up in `yarn build` for `HistoryViewer.scss`. The plain declarations in `&__spinner` are moved above the nested `&, &:after` rule, which is what Sass recommends to keep the current cascade behaviour. Compiled CSS is byte for byte unchanged.

The other build warnings (`@import` deprecation, vendor `lighten()`, legacy JS API) can't be resolved cleanly from this module yet — they depend on upstream Bootstrap / `silverstripe/admin` / `@silverstripe/webpack-config`. Documented in #120.

## Manual testing steps

- `yarn build`
- no more "declarations that appear after nested rules" warnings for `HistoryViewer.scss`, output is unchanged

## Issues

- #120

## Pull request checklist

- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR
- [x] The commit messages follow our commit message guidelines
- [x] The PR follows our contribution guidelines
- [x] Code changes follow our coding conventions
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated (`MNT` change, excluded from the changelog)
- [ ] CI is green
